### PR TITLE
Local cache backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ backup/
 Cargo.lock
 !./Cargo.lock
 rusty-tags.vi
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["lib/**/*", "tester/**"]
 edition = "2021"
 
 [features]
-default = ["with-bzip2","with-deflate","with-xz2","with-zstd"]
+default = ["with-bzip2","with-deflate","with-zstd"]
 with-bzip2 = ["rdedup-lib/with-bzip2"]
 with-deflate = ["rdedup-lib/with-deflate"]
 with-xz2 = ["rdedup-lib/with-xz2"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ name = "rdedup_lib"
 path = "src/lib.rs"
 
 [features]
-default = ["with-bzip2", "with-deflate", "with-xz2", "with-zstd", "backend-b2"]
+default = ["with-bzip2", "with-deflate", "with-zstd", "backend-b2"]
 # Optional compression features
 with-bzip2 = ["bzip2"]
 with-deflate = ["flate2"]

--- a/lib/src/aio/local_cache.rs
+++ b/lib/src/aio/local_cache.rs
@@ -1,0 +1,135 @@
+use std::path::PathBuf;
+use std::sync::mpsc::Sender;
+use sgdata::SGData;
+use crate::aio::{Local, Metadata};
+use crate::backends::{Backend, BackendThread, Lock};
+
+//#[derive(Debug)]
+pub struct LocalCache {
+    local: Box<Local>,
+    remote: Box<dyn Backend>,
+}
+
+struct CombinedLocks {
+    locks: Vec<Box<dyn Lock>>
+}
+
+impl CombinedLocks {
+    fn new(locks: Vec<Box<dyn Lock>>) -> Self {
+        CombinedLocks { locks }
+    }
+}
+
+impl Lock for CombinedLocks {}
+
+pub struct LocalCacheThread {
+    local: Box<dyn BackendThread>,
+    remote: Box<dyn BackendThread>,
+}
+
+impl LocalCache {
+    pub fn new(path: PathBuf, remote: Box<dyn Backend>) -> Self {
+       LocalCache { local: Box::new(Local::new(path)), remote }
+    }
+}
+
+impl Backend for LocalCache {
+    fn lock_exclusive(&self) -> std::io::Result<Box<dyn Lock>> {
+        let remote_lock = self.remote.lock_exclusive()?;
+        let local_lock = self.local.lock_exclusive()?;
+        Ok(Box::new(CombinedLocks::new(vec![remote_lock, local_lock])))
+    }
+
+    fn lock_shared(&self) -> std::io::Result<Box<dyn Lock>> {
+        let remote_lock = self.remote.lock_shared()?;
+        let local_lock = self.local.lock_shared()?;
+        Ok(Box::new(CombinedLocks::new(vec![remote_lock, local_lock])))
+    }
+
+    fn new_thread(&self) -> std::io::Result<Box<dyn BackendThread>> {
+        let local_thread = self.local.new_thread()?;
+        let remote_thread = self.remote.new_thread()?;
+        Ok(
+            Box::new(LocalCacheThread {
+                local: local_thread,
+                remote: remote_thread
+            })
+        )
+    }
+}
+
+impl BackendThread for LocalCacheThread {
+    // We generally delegate the write operation to the remote store first; and then duplicate them locally if it succeeded only.
+    // Read operations try to hit the local cache first, and delegate to the remote on error (assuming there was no cached value).
+
+    fn remove_dir_all(&mut self, path: PathBuf) -> std::io::Result<()> {
+        let result = self.remote.remove_dir_all(path.clone());
+        match result {
+            Ok(()) => self.local.remove_dir_all(path),
+            Err(e) => Err(e)
+        }
+    }
+
+    fn rename(&mut self, src_path: PathBuf, dst_path: PathBuf) -> std::io::Result<()> {
+        let result = self.remote.rename(src_path.clone(), dst_path.clone());
+        match result {
+            Ok(()) => self.local.rename(src_path, dst_path),
+            Err(e) => Err(e)
+        }
+    }
+
+    fn write(&mut self, path: PathBuf, sg: SGData, idempotent: bool) -> std::io::Result<()> {
+        let result = self.remote.write(path.clone(), sg.clone(), idempotent);
+        match result {
+            Ok(()) => self.local.write(path, sg, idempotent),
+            Err(e) => Err(e)
+        }
+    }
+
+    fn read(&mut self, path: PathBuf) -> std::io::Result<SGData> {
+        let result = self.local.read(path.clone());
+        match result {
+            Ok(data) => {
+                eprintln!("Cache HIT for chunk {}", path.display());
+                Ok(data)
+            },
+            Err(_) => { // TODO: check if different errors can occur, and only fetch from remote when it's an expected "no such file" or similar error?
+                eprintln!("Cache MISS for chunk {}", path.display());
+                match self.remote.read(path.clone()) {
+                    Ok(data) => {
+                        // TODO: I am pretty sure higher level code is in charge of having taken a shared lock for this read; and so that
+                        // triggering a write here is probably a Bad Thing without an exclusive lock. I need to study the codebase more to see
+                        // what to do! Potentially, a dependency of the cache backend is missing: a way to manipulate locks given to it?
+                        let cache_result = self.local.write(path, data.clone(), false);
+                        if cache_result.is_err() {
+                            eprintln!("Successfully read data from remote; but failed to cache it!");
+                        }
+                        Ok(data)
+                    },
+                    Err(e) => Err(e)
+                }
+            }
+        }
+    }
+
+    fn remove(&mut self, path: PathBuf) -> std::io::Result<()> {
+        let result = self.remote.remove(path.clone());
+        match result {
+            Ok(()) => self.local.remove(path),
+            Err(e) => Err(e)
+        }
+    }
+
+    fn read_metadata(&mut self, path: PathBuf) -> std::io::Result<Metadata> {
+        self.remote.read_metadata(path.clone())
+    }
+
+    // Simply rely on the remote as the ground truth for listing
+    fn list(&mut self, path: PathBuf) -> std::io::Result<Vec<PathBuf>> {
+        self.remote.list(path)
+    }
+
+    fn list_recursively(&mut self, path: PathBuf, tx: Sender<std::io::Result<Vec<PathBuf>>>) {
+        self.remote.list_recursively(path, tx)
+    }
+}

--- a/lib/src/aio/mod.rs
+++ b/lib/src/aio/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod b2;
 pub(crate) use self::b2::B2;
 
 pub(crate) mod backend;
+pub(crate) mod local_cache;
+
 use self::backend::*;
 
 // {{{ Misc
@@ -33,7 +35,7 @@ struct WriteArgs {
     complete_tx: Option<mpsc::Sender<io::Result<()>>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Metadata {
     pub len: u64,
     pub is_file: bool,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -120,13 +120,15 @@
 
 use std::str::FromStr;
 use std::{env, io, path::PathBuf, process};
-
+use std::sync::Arc;
 use clap::{Parser, Subcommand};
 use slog::{info, o, Drain};
 use url::Url;
 
 use rdedup_lib as lib;
-
+use rdedup_lib::backends::Backend;
+use rdedup_lib::backends::local::Local;
+use rdedup_lib::backends::local_cache::LocalCache;
 use crate::lib::settings;
 use crate::lib::Repo;
 
@@ -143,13 +145,15 @@ fn parse_url(s: &str) -> io::Result<Url> {
 #[derive(Clone)]
 struct Options {
     url: Url,
+    cache_dir: Option<PathBuf>,
     settings: settings::Repo,
 }
 
 impl Options {
-    fn new(url: Url) -> Options {
+    fn new(url: Url, cache_dir: Option<PathBuf>) -> Options {
         Options {
             url,
+            cache_dir,
             settings: settings::Repo::new(),
         }
     }
@@ -317,6 +321,11 @@ struct CliOpts {
     /// Path to rdedup repository. Override `RDEDUP_DIR` environment variable
     repo_dir: Option<std::ffi::OsString>,
 
+    // TODO add an `RDEDUP_CACHE_DIR` environment variable for feature parity with --dir and -u
+    #[clap(name = "cachedir", short = 'c', long, value_name = "PATH", required = false)]
+    /// Path to a cache repository. Useful for read speedups when the real repo given to --dir is a network drive.
+    cache_dir: Option<std::ffi::OsString>,
+
     #[clap(
         short = 'u',
         long = "repo",
@@ -464,6 +473,19 @@ enum Command {
     },
 }
 
+fn create_backend(options: &Options) -> io::Result<Box<dyn Backend + Send + Sync>> {
+    match rdedup_lib::backends::from_url(&options.url) {
+        Ok(backend) => {
+            if options.cache_dir.is_none() {
+                return Ok(backend);
+            }
+
+            Ok(Box::new(LocalCache::new(options.cache_dir.clone().unwrap(), backend)))
+        }
+        Err(e) => Err(e)
+    }
+}
+
 fn run() -> io::Result<()> {
     let cli_opts = CliOpts::parse();
 
@@ -511,7 +533,11 @@ fn run() -> io::Result<()> {
         process::exit(-1);
     };
 
-    let mut options = Options::new(url);
+    let cache_dir : Option<PathBuf> = if let Some(dir) = cli_opts.cache_dir {
+        Some(PathBuf::from(&dir).canonicalize()?)
+    } else { None };
+
+    let mut options = Options::new(url, cache_dir);
 
     let log =
         create_logger(cli_opts.verbose as u32, cli_opts.verbose_timings as u32);
@@ -541,39 +567,53 @@ fn run() -> io::Result<()> {
             options.settings.set_compression_level(compression_level);
             options.set_nesting(nesting);
             options.set_hashing(&hashing);
-            let _ = Repo::init(
-                &options.url,
+            if options.cache_dir.is_some() {
+                // We create the cache first since it is optional; so we only clone the settings and
+                // the logger if necessary
+                // TODO atm the cache is a local repo; but abstraction levels are all over the place
+                // since it is implemented as a special backend. Should the cache be implemented as
+                // a whole cache _repo_? Or should we seamlessly use the caching backend without
+                // needing to "seed" it as a repo? Tests and thinking needed!
+                let _ = Repo::init(
+                        Arc::new(move || Ok(Box::new(Local::new(options.cache_dir.clone().unwrap())))),
+                        &read_new_passphrase,
+                        options.settings.clone(),
+                        log.clone(),
+                    )?;
+            let _ = Repo::init_from_url(
+                Arc::new(options.url.clone()),
                 &read_new_passphrase,
                 options.settings,
                 log,
             )?;
+            }
         }
         Command::Store { name } => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
             let enc = repo.unlock_encrypt(&read_passphrase)?;
             let stats = repo.write(&name, &mut io::stdin(), &enc)?;
             println!("{} new chunks", stats.new_chunks);
             println!("{} new bytes", stats.new_bytes);
         }
         Command::Load { name } => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
             let dec = repo.unlock_decrypt(&read_passphrase)?;
             repo.read(&name, &mut io::stdout(), &dec)?;
         }
         Command::ChangePassphrase => {
-            let mut repo = Repo::open(&options.url, log)?;
+            let mut repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
             repo.change_passphrase(&read_passphrase, &|| {
                 read_new_passphrase()
             })?;
         }
         Command::Remove { names } => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
             for name in names {
                 repo.rm(&name)?;
             }
         }
         Command::Du { names } => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
             let dec = repo.unlock_decrypt(&read_passphrase)?;
 
             for name in names {
@@ -583,19 +623,19 @@ fn run() -> io::Result<()> {
             }
         }
         Command::Gc { grace_time } => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
 
             repo.gc(grace_time)?;
         }
         Command::List => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
 
             for name in repo.list_names()? {
                 println!("{}", name);
             }
         }
         Command::Verify { names } => {
-            let repo = Repo::open(&options.url, log)?;
+            let repo = Repo::open(Arc::new(move || create_backend(&options)), log)?;
             let dec = repo.unlock_decrypt(&read_passphrase)?;
             for name in names {
                 let results = repo.verify(&name, &dec)?;


### PR DESCRIPTION
Implemented a "meta" backend called LocalCache, which has a `remote` backend containing the "real" ground-truth repo but also a `local` backend of type `Local` which caches chunks as they are `read` from the remote so as to produce them on the next `read`, speeding up `load` operations when the local cache can live on the local filesystem and the remote is not.